### PR TITLE
fix: 빈 리스트 상황에서 가장 오래된 값 확인을 선택할 때 '값이 0.0 입니다'로 출력되는 문제

### DIFF
--- a/src/main/java/com/example/calculatorLv2/App.java
+++ b/src/main/java/com/example/calculatorLv2/App.java
@@ -137,7 +137,14 @@ public class App {
                     return;
                 }
                 else if (input.equals("1") || input.equals("확인")){
-                    System.out.println("가장 오래된 결과값을 확인합니다: " + myCalculator.getResultOldest());
+                    System.out.println("가장 오래된 결과값을 확인합니다.");
+                    try {
+                        double temp = myCalculator.getResultOldest();
+                        System.out.println("가장 오래된 결과값은 [" + temp + "]입니다.");
+                    }
+                    catch(Exception e) {
+                        System.out.println("비어있습니다.");
+                    }
                 }
                 else if (input.equals("2") || input.equals("수정")) {
                     System.out.print("가장 오래된 결과값을 어떤 값으로 수정할까요 >> ");

--- a/src/main/java/com/example/calculatorLv2/Calculator.java
+++ b/src/main/java/com/example/calculatorLv2/Calculator.java
@@ -45,12 +45,11 @@ public class Calculator {
     }
 
     // 필드에 간접 접근하여 가장 오래된 결과값을 가져오는 Getter 메서드
-    public double getResultOldest() {
+    public double getResultOldest() throws Exception {
         if (resultList.peekFirst() != null)     // 안전한 조회 peekFirst
             return resultList.peekFirst();
-        else
-            System.out.println("비어있습니다.");
-        return 0;
+        else    // 비어있는 경우
+            throw new Exception();
     }
 
     // 필드에 간접 접근하여 가장 오래된 결과값을 수정하는 Setter 메서드
@@ -62,7 +61,6 @@ public class Calculator {
             resultList.set(0, newResult);
             return true;
         }
-
     }
 
     // 필드에 간접 접근하여 가장 오래된 결과값을 제거하는 메서드


### PR DESCRIPTION
예상원인
Calculator 클래스의 double getResultOldest() 메소드가 사용자에게 비어있다는 알림은 보내지만 메소드를 사용하는 다른 클래스에게는 비어있는 것을 알리지 않는다.
그래서, 해당 메소드를 사용하는 App 클래스의 main 메소드가 비어있는 상황을 처리할 수 없다. 해결방안
try-throw-catch로 예외를 발생시켜서 해결했다.

resolves: #25